### PR TITLE
Automated workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,19 +13,19 @@
 		<maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
 		<timestamp>${maven.build.timestamp}</timestamp>
 
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 
 		<!-- Node/Yarn Versions -->
-		<version.node-js>8.15.0</version.node-js>
-		<version.yarn>1.15.2</version.yarn>
+		<version.node-js>16.15.0</version.node-js>
+		<version.yarn>1.22.18</version.yarn>
 
 		<!-- Dependency Versions -->
 		<version.com.fasterxml.jackson>2.11.2</version.com.fasterxml.jackson>
 		<version.com.fasterxml.jackson.dataformat>2.10.0.pr1</version.com.fasterxml.jackson.dataformat>
 		<version.commons-io>2.8.0</version.commons-io>
 		<version.junit>4.13</version.junit>
-		<version.org.jsweet>2.3.6</version.org.jsweet>
+		<version.org.jsweet>3.1.0</version.org.jsweet>
 		<version.org.skyscreamer>1.5.0</version.org.skyscreamer>
 
 		<!-- Plugin Versions -->

--- a/src/main/html/test.html
+++ b/src/main/html/test.html
@@ -7,7 +7,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <script type="text/javascript" src="file:///C:/Users/Eric/git/other/jsweet-reproducer/target/ts/dist/bundles/jsweet-reproducer.umd.js"></script>
+    <script type="text/javascript" src="file:///Users/aperuffo/workspace/jsweet-reproducer2/target/ts/dist/bundles/jsweet-reproducer.umd.js"></script>
     <script>
     	console.info("Start test: ", reproducer);
     	console.info("Library object: ", reproducer.Library);

--- a/src/main/ts/.eslintrc.js
+++ b/src/main/ts/.eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "project": ['./tsconfig-package.json'],
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "plugins": [
+        "@typescript-eslint", "simple-import-sort"
+    ],
+    "rules": {
+        "simple-import-sort/imports": "error",
+        "simple-import-sort/exports": "error",
+        "@typescript-eslint/consistent-type-imports": "error",
+        "@typescript-eslint/consistent-type-exports": "error"
+    }
+}

--- a/src/main/ts/package.json
+++ b/src/main/ts/package.json
@@ -14,7 +14,7 @@
     "definition": "index.d.ts"
   },
   "scripts": {
-    "package": "rimraf dist && tsc -p tsconfig-package.json && cpx package.json dist && cpx module/*.* dist && mkdirp ./dist/bundles && rollup -c rollup.config.js"
+    "package": "eslint --fix 'src/**' && rimraf dist && tsc -p tsconfig-package.json && cpx package.json dist && cpx module/*.* dist && mkdirp ./dist/bundles && rollup -c rollup.config.js"
   },
   "dependencies": {
     "core-js": "3.6.5"
@@ -31,6 +31,10 @@
     "rollup": "0.68.2",
     "rollup-plugin-commonjs": "8.4.1",
     "ts-jest": "24.3.0",
-    "typescript": "4.0.3"
+    "typescript": "4.0.3",
+    "@typescript-eslint/eslint-plugin": "^5.33.0",
+    "@typescript-eslint/parser": "^5.33.0",
+    "eslint": "^8.21.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0"
   }
 }

--- a/src/main/ts/tsconfig-package.json
+++ b/src/main/ts/tsconfig-package.json
@@ -17,7 +17,8 @@
     "inlineSources": true,
     "target": "es5",
     "lib": ["es2015", "dom"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "importsNotUsedAsValues": "error"
   },
   "files": [
     "index.ts"


### PR DESCRIPTION
Opening this as a reference.

This is a "possible" attempt (to be tested on a larger project) that seems to workaround the original problem.
A couple of notes:
- the root cause of the issue are circular dependencies, running `npx madge --circular --extensions ts ./src` in the `target/ts` folder still gives 54 circular dependencies (down to 26 in `./dist`)
- the attempt to mitigate the problem by using `consistent-type-imports` and `consistent-type-exports` automatic fix is not enough (using [Type-Only imports/exports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html))
- adding `imports` (and `exports` for consistency) sorting happens to generate a working result

A possible solution(to be tested) might be to implement the ["internal module pattern"](https://link.medium.com/ncZGWd84nsb) in JSweet itself(where the dependency graph is available).